### PR TITLE
[Feat] Add CMake as the primary builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+
+# build folders
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+# =============================================================================
+# Benchmark on data sortedness
+# =============================================================================
+cmake_minimum_required(VERSION 3.16)
+project(bods VERSION 1.0
+    DESCRIPTION "Benchmark on data sortedness"
+    LANGUAGES CXX
+)
+
+message(STATUS "CXX : ${CMAKE_CXX_COMPILER}")
+
+# =============================================================================
+# HEADER Options
+# =============================================================================
+option(DEBUG "Debug mode on or off" OFF)
+if(${DEBUG})
+    set(CMAKE_BUILD_TYPE "Debug")
+else()
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# =============================================================================
+# HEADER Dependencies
+# =============================================================================
+find_package(Boost REQUIRED)
+
+# =============================================================================
+# HEADER bods
+# =============================================================================
+set(BODS_SRCS
+    src/sortedness_data_generator.cpp
+)
+
+add_executable(sortedness_data_generator ${BODS_SRCS})
+
+target_include_directories(sortedness_data_generator PUBLIC
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(sortedness_data_generator PUBLIC
+    Boost::boost
+)


### PR DESCRIPTION
# Context

CMake is a standard build system that allows for easier integration into multiple platforms and other projects. Therefore we have added a started `CMakeLists.txt` file to start off with. We can proceed to deprecate the Make file after this.

# Misc

Added the standard cpp .gitignore