### PR TITLE
Add auto-output filename, update args.toml and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ reverse_order = true
 
 ```
 
+Note: the TOML format supports two new optional fields to control where
+generated files are placed and whether filenames are auto-generated:
+
+- `global.output_dir` (string): directory to use when auto-generating output filenames. Default is `../workloads`.
+- `partition.auto_output_filename` (bool): when `true` the generator builds a filename using the pattern `createdata_N..._K..._L..._S..._a..._b..._P....txt` and writes it into `global.output_dir`. If `false`, the generator uses `partition.output_file`.
+
+See `src/args.toml` for an example that includes comments showing these options.
+
 This will by default generate a comma separated txt file with the key in the first column and a randomly generated payload (string) in the second column.
 
 To run the data generator with mutiple workload descriptions, follow the format shown below in the sample completed workload description:

--- a/src/args.toml
+++ b/src/args.toml
@@ -3,17 +3,30 @@ title = "Single Workload Description"
 [global]
 domain = 10000000
 
+# Optional: directory where generated output files will be written when
+# `auto_output_filename` is enabled for a partition. Default: "../workloads".
+output_dir = "../workloads"
+
 [[partition]]
 start_index = 0
-number_of_entries = 1000000
-K = 10
-L = 10
+number_of_entries = 2000
+K = 41
+L = 1
 seed = 1234
 alpha = 1
 beta = 1
-payload = 252
+payload = 0
 window_size = 1
-output_file = "../workloads/createdata_N1000000_K10_L10_S1234_a1_b1_P252.txt"
 is_fixed = false
 is_binary = false
-reverse_order = true
+reverse_order = false
+
+# If true, the generator will ignore `output_file` and automatically
+# construct a filename using the convention:
+# createdata_N<num_entries>_K<k%>_L<l%>_S<seed>_a<alpha>_b<beta>_P<payload>.txt
+# and place it under `global.output_dir` above.
+auto_output_filename = true
+
+# You may optionally still provide an explicit `output_file` path. If
+# `auto_output_filename` is true the explicit value will be ignored.
+output_file = "../workloads/createdata_N2000_K40_L10_S1234_a1_b1_P252.txt"


### PR DESCRIPTION
This PR adds auto-generated output filename support for the generator (reads global.output_dir and partition.auto_output_filename), logs the output path, updates src/args.toml with comments and README entries, and adds the analysis script and README updates.